### PR TITLE
feat: add markdown-template required methods

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -43,6 +43,7 @@
 - `Server.security()` : ServerSecurity[] (outcome of https://github.com/asyncapi/markdown-template/blob/master/components/Servers.js#L38 and https://github.com/asyncapi/markdown-template/blob/master/components/Servers.js#L73-L93)
 
 ### ServerVariable
+- `ServerVariable.name()` : string (outcome of https://github.com/asyncapi/markdown-template/blob/master/components/Servers.js/#L49)
 - `ServerVariable.hasDefaultValue()` : boolean (outcome of https://github.com/asyncapi/markdown-template/blob/master/components/Servers.js/#L49-L54)
 - `ServerVariable.defaultValue()` : string (outcome of https://github.com/asyncapi/markdown-template/blob/master/components/Servers.js/#L49-L54)
 - `ServerVariable.hasAllowedValues()` : boolean (outcome of https://github.com/asyncapi/markdown-template/blob/master/components/Servers.js/#L49-L54)

--- a/docs/API.md
+++ b/docs/API.md
@@ -54,8 +54,8 @@
 - `ServerSecurity.values()` : string[] (outcome of https://github.com/asyncapi/markdown-template/blob/master/components/Servers.js#L75-L80)
 
 ### SecurityScheme
-- `SecurityScheme.type()` : string (outcome of https://github.com/asyncapi/markdown-template/blob/master/components/Servers.js#L75-L80)
-- `SecurityScheme.in()` : string (outcome of https://github.com/asyncapi/markdown-template/blob/master/components/Servers.js#L75-L80)
+- `SecurityScheme.type()` : Types (outcome of https://github.com/asyncapi/markdown-template/blob/master/components/Servers.js#L75-L80)
+- `SecurityScheme.in()` : ApiKeyLocations (outcome of https://github.com/asyncapi/markdown-template/blob/master/components/Servers.js#L75-L80)
 - `SecurityScheme.name()` : string (outcome of https://github.com/asyncapi/markdown-template/blob/master/components/Servers.js#L75-L80)
 - `SecurityScheme.scheme()` : string (outcome of https://github.com/asyncapi/markdown-template/blob/master/components/Servers.js#L75-L80)
 - `SecurityScheme.bearerFormat()` : string (outcome of https://github.com/asyncapi/markdown-template/blob/master/components/Servers.js#L75-L80)

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,3 +1,6 @@
+### All models (Base)
+- `<base>.hasExtension(key)` : boolean (outcome of https://github.com/asyncapi/parser-js/blob/b06e44f519f31fcda11336eb6d84aaf1d4630366/lib/parser.js#L129)
+- `<base>.extension(key)` : any (outcome of https://github.com/asyncapi/parser-js/blob/b06e44f519f31fcda11336eb6d84aaf1d4630366/lib/parser.js#L129)
 
 ### Root - AsyncAPIDocument
 - `AsyncAPIDocument.applicationPublishableChannels()` : Channel[] (outcome of comment(s): [800282407](https://github.com/asyncapi/shape-up-process/issues/84#issuecomment-800282407), [800935961](https://github.com/asyncapi/shape-up-process/issues/84#issuecomment-800935961))
@@ -13,10 +16,12 @@
 - `AsyncAPIDocument.clientSubscribableMessages()` : Message[]
 - `AsyncAPIDocument.clientSubscribeOperations()` : Operation[]
 - `AsyncAPIDocument.messages(<message name>[])` : Message[] (outcome of comment(s): [800935961](https://github.com/asyncapi/shape-up-process/issues/84#issuecomment-800935961))
+- `AsyncAPIDocument.hasChannels()` : boolean (outcome of https://github.com/asyncapi/markdown-template/blob/master/template/asyncapi.js#L32)
 - `AsyncAPIDocument.channels(<channel name>[])` : Channel[] (outcome of comment(s): [800282407](https://github.com/asyncapi/shape-up-process/issues/84#issuecomment-800282407), [800935961](https://github.com/asyncapi/shape-up-process/issues/84#issuecomment-800935961))
 - `AsyncAPIDocument.operations(<operation id>[])` : Operation[]		
 - `AsyncAPIDocument.hasContentType('<content type>')` : boolean (outcome of comment(s): [799481319](https://github.com/asyncapi/shape-up-process/issues/84#issuecomment-799481319))
 - `AsyncAPIDocument.schemas()` : Schema[] (outcome of comment(s): [800935961](https://github.com/asyncapi/shape-up-process/issues/84#issuecomment-800935961))
+- `AsyncAPIDocument.hasServers()` : boolean (outcome of https://github.com/asyncapi/markdown-template/blob/master/template/asyncapi.js#L32)
 - `AsyncAPIDocument.servers()` : Server[] (outcome of comment(s): [800935961](https://github.com/asyncapi/shape-up-process/issues/84#issuecomment-800935961))
 - `AsyncAPIDocument.server('<server name>')` : Server (outcome of comment(s): [800935961](https://github.com/asyncapi/shape-up-process/issues/84#issuecomment-800935961))
 - `AsyncAPIDocument.info()` : Info
@@ -26,18 +31,41 @@
 - `Info.title()` : string (outcome of comment(s): [799481319](https://github.com/asyncapi/shape-up-process/issues/84#issuecomment-799481319), [799598596](https://github.com/asyncapi/shape-up-process/issues/84#issuecomment-799598596), [800282407](https://github.com/asyncapi/shape-up-process/issues/84#issuecomment-800282407), [800963792](https://github.com/asyncapi/shape-up-process/issues/84#issuecomment-800963792))
 - `Info.description()` : string (outcome of comment(s): [799481319](https://github.com/asyncapi/shape-up-process/issues/84#issuecomment-799481319), [799598596](https://github.com/asyncapi/shape-up-process/issues/84#issuecomment-799598596), [800282407](https://github.com/asyncapi/shape-up-process/issues/84#issuecomment-800282407))
 - `Info.version()` : string (outcome of comment(s): [799481319](https://github.com/asyncapi/shape-up-process/issues/84#issuecomment-799481319), [799598596](https://github.com/asyncapi/shape-up-process/issues/84#issuecomment-799598596), [800282407](https://github.com/asyncapi/shape-up-process/issues/84#issuecomment-800282407), [800963792](https://github.com/asyncapi/shape-up-process/issues/84#issuecomment-800963792))
+- `Info.termsOfService()` : string (outcome of https://github.com/asyncapi/markdown-template/blob/master/template/asyncapi.js#L27)
 
 ### Server
 - `Server.name()` : string
 - `Server.protocol()` : string (outcome of comment(s): [800282407](https://github.com/asyncapi/shape-up-process/issues/84#issuecomment-800282407))
 - `Server.operations()` : Operation[]
+- `Server.protocolVersion()` : string (outcome of https://github.com/asyncapi/markdown-template/blob/master/components/Servers.js#L27)
+- `Server.description()` : string (outcome of https://github.com/asyncapi/markdown-template/blob/master/components/Servers.js#L28)
+- `Server.variables()` : ServerVariable[] (outcome of https://github.com/asyncapi/markdown-template/blob/master/components/Servers.js#L37)
+- `Server.security()` : ServerSecurity[] (outcome of https://github.com/asyncapi/markdown-template/blob/master/components/Servers.js#L38 and https://github.com/asyncapi/markdown-template/blob/master/components/Servers.js#L73-L93)
+
+### ServerVariable
+- `ServerVariable.hasDefaultValue()` : boolean (outcome of https://github.com/asyncapi/markdown-template/blob/master/components/Servers.js/#L49-L54)
+- `ServerVariable.defaultValue()` : string (outcome of https://github.com/asyncapi/markdown-template/blob/master/components/Servers.js/#L49-L54)
+- `ServerVariable.hasAllowedValues() boolean (outcome of https://github.com/asyncapi/markdown-template/blob/master/components/Servers.js/#L49-L54)
+- `ServerVariable.allowedValues()` : any[] (outcome of https://github.com/asyncapi/markdown-template/blob/master/components/Servers.js/#L49-L54)
+- `ServerVariable.description() string (outcome of https://github.com/asyncapi/markdown-template/blob/master/components/Servers.js/#L49-L54)
+
+### ServerSecurity
+- `ServerSecurity.securityScheme()` : SecurityScheme (outcome of https://github.com/asyncapi/markdown-template/blob/master/components/Servers.js#L75-L80)
+- `ServerSecurity.values()` : string[] (outcome of https://github.com/asyncapi/markdown-template/blob/master/components/Servers.js#L75-L80)
 
 ### SecurityScheme
-Empty for now.
+- `SecurityScheme.type()` : string (outcome of https://github.com/asyncapi/markdown-template/blob/master/components/Servers.js#L75-L80)
+- `SecurityScheme.in()` : string (outcome of https://github.com/asyncapi/markdown-template/blob/master/components/Servers.js#L75-L80)
+- `SecurityScheme.name()` : string (outcome of https://github.com/asyncapi/markdown-template/blob/master/components/Servers.js#L75-L80)
+- `SecurityScheme.scheme()` : string (outcome of https://github.com/asyncapi/markdown-template/blob/master/components/Servers.js#L75-L80)
+- `SecurityScheme.bearerFormat()` : string (outcome of https://github.com/asyncapi/markdown-template/blob/master/components/Servers.js#L75-L80)
 
 ### Operation
 - `Operation.id()` : string
 - `Operation.summary()` : string
+- `Operation.hasDescription()` : boolean (outcome of https://github.com/asyncapi/markdown-template/blob/master/components/Channels.js#L69-L71)
+- `Operation.description()` : string (outcome of https://github.com/asyncapi/markdown-template/blob/master/components/Channels.js#L69-L71)
+- `Operation.hasMultipleMessages()` : boolean (outcome of https://github.com/asyncapi/markdown-template/blob/master/components/Channels.js#L74)
 - `Operation.messages()` : Message[]
 - `Operation.channels()` : Channel[]
 - `Operation.extension('<extension property>')` : any
@@ -51,15 +79,28 @@ Empty for now.
 - `Operation.type()` : string - Returns either `ClientSubscribing`, `ClientPublishing`, `ApplicationSubscribing`, `ApplicationPublishing`
 
 ### Channel
+- `Channel.name()` : string (outcome of https://github.com/asyncapi/markdown-template/blob/master/components/Channels.js#L26)
 - `Channel.path()` : string
 - `Channel.messages()` : Message[]
 - `Channel.operations()` : Operation[]
+- `Channel.hasDescription()` : boolean (outcome of https://github.com/asyncapi/markdown-template/blob/master/components/Channels.js#L28)
 - `Channel.description()` : string (outcome of comment(s): [799481319](https://github.com/asyncapi/shape-up-process/issues/84#issuecomment-799481319), [800282407](https://github.com/asyncapi/shape-up-process/issues/84#issuecomment-800282407))
 - `Channel.extension('<extension property>')` : any (outcome of comment(s): [799598596](https://github.com/asyncapi/shape-up-process/issues/84#issuecomment-799598596))
 - `Channel.binding('<binding protocol>')` : any (outcome of comment(s): [799481319](https://github.com/asyncapi/shape-up-process/issues/84#issuecomment-799481319), [799598596](https://github.com/asyncapi/shape-up-process/issues/84#issuecomment-799598596))
-- `Channel.parameters()` : Schema[] (outcome of comment(s): [800935961](https://github.com/asyncapi/shape-up-process/issues/84#issuecomment-800935961))
+- `Channel.hasParameters()` : boolean (outcome of https://github.com/asyncapi/markdown-template/blob/master/components/Channels.js#L34)
+- `Channel.parameters()` : ChannelParameter[] (outcome of comment(s): [800935961](https://github.com/asyncapi/shape-up-process/issues/84#issuecomment-800935961) and https://github.com/asyncapi/markdown-template/blob/master/components/Channels.js#L34)
+
+### ChannelParameter
+- `ChannelParameter.name()` : string (outcome of https://github.com/asyncapi/markdown-template/blob/master/components/Channels.js#L47)
+- `ChannelParameter.schema()` : Schema (outcome of https://github.com/asyncapi/markdown-template/blob/master/components/Channels.js#L48)
 
 ### Message
+- `Message.summary()` : string (outcome of https://github.com/asyncapi/markdown-template/blob/master/components/Message.js#L11)
+- `Message.hasDescription()` : string (outcome of https://github.com/asyncapi/markdown-template/blob/master/components/Message.js#L16)
+- `Message.description()` : string (outcome of https://github.com/asyncapi/markdown-template/blob/master/components/Message.js#L18)
+- `Message.examples()` : Object<string, any>[] (outcome of https://github.com/asyncapi/markdown-template/blob/master/components/Message.js#L65)
+- `Message.hasTags()` : string (outcome of https://github.com/asyncapi/markdown-template/blob/master/components/Message.js#L38)
+- `Message.tags()` : Tag[] (outcome of https://github.com/asyncapi/markdown-template/blob/master/components/Message.js#L41)
 - `Message.headers()` : Schema (outcome of comment(s): [800282407](https://github.com/asyncapi/shape-up-process/issues/84#issuecomment-800282407))
 - `Message.payload()` : Schema (outcome of comment(s): [799481319](https://github.com/asyncapi/shape-up-process/issues/84#issuecomment-799481319), [799598596](https://github.com/asyncapi/shape-up-process/issues/84#issuecomment-799598596))
 - `Message.channels()` : Channel[]
@@ -67,3 +108,6 @@ Empty for now.
 - `Message.extension('<extension property>')` : any
 - `Message.binding('<binding protocol>')` : any
 - `Message.contentType()` : string
+
+### Tag
+- `Tag.name()` : string (outcome of https://github.com/asyncapi/markdown-template/blob/master/components/Message.js#L52)

--- a/docs/API.md
+++ b/docs/API.md
@@ -45,9 +45,9 @@
 ### ServerVariable
 - `ServerVariable.hasDefaultValue()` : boolean (outcome of https://github.com/asyncapi/markdown-template/blob/master/components/Servers.js/#L49-L54)
 - `ServerVariable.defaultValue()` : string (outcome of https://github.com/asyncapi/markdown-template/blob/master/components/Servers.js/#L49-L54)
-- `ServerVariable.hasAllowedValues() boolean (outcome of https://github.com/asyncapi/markdown-template/blob/master/components/Servers.js/#L49-L54)
+- `ServerVariable.hasAllowedValues()` : boolean (outcome of https://github.com/asyncapi/markdown-template/blob/master/components/Servers.js/#L49-L54)
 - `ServerVariable.allowedValues()` : any[] (outcome of https://github.com/asyncapi/markdown-template/blob/master/components/Servers.js/#L49-L54)
-- `ServerVariable.description() string (outcome of https://github.com/asyncapi/markdown-template/blob/master/components/Servers.js/#L49-L54)
+- `ServerVariable.description()` : string (outcome of https://github.com/asyncapi/markdown-template/blob/master/components/Servers.js/#L49-L54)
 
 ### ServerSecurity
 - `ServerSecurity.securityScheme()` : SecurityScheme (outcome of https://github.com/asyncapi/markdown-template/blob/master/components/Servers.js#L75-L80)

--- a/docs/API.md
+++ b/docs/API.md
@@ -79,8 +79,7 @@
 - `Operation.type()` : string - Returns either `ClientSubscribing`, `ClientPublishing`, `ApplicationSubscribing`, `ApplicationPublishing`
 
 ### Channel
-- `Channel.name()` : string (outcome of https://github.com/asyncapi/markdown-template/blob/master/components/Channels.js#L26)
-- `Channel.path()` : string
+- `Channel.path()` : string (outcome of https://github.com/asyncapi/markdown-template/blob/master/components/Channels.js#L26)
 - `Channel.messages()` : Message[]
 - `Channel.operations()` : Operation[]
 - `Channel.hasDescription()` : boolean (outcome of https://github.com/asyncapi/markdown-template/blob/master/components/Channels.js#L28)


### PR DESCRIPTION
This PR adds all methods required by https://github.com/asyncapi/markdown-template to the new Parser API.